### PR TITLE
Add more e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,18 @@ cargo run -- orchestrator --ethereum-rpc="http://localhost:8545" --baseledger-co
 
 ## Running a local dockerized testnet
 
+Scripts that have N and M next to name has optional parameter to control how many nodes and orchestrators will be spawn. If you leave these out, there will be 3 by default
+
 - Navigate to tests
 - Run build-container.sh - This should be ran only once to build the docker images.
-- Run start-containers.sh - Starts 3 baseledger nodes and a hardhat node.
-- Run deploy-contracts.sh - This deploys the dummy UBT token contract as well as the BaseledgerUBTSplitter contract
-- Run setup-validators.sh - Creates and shares genesis.json among validators and creates gentx files.
-- Run run-testnet.sh - Starts the nodes, registers and starts the orchestrators. 
+- Run start-containers.sh N - Starts N (default 3) baseledger nodes and a hardhat node. 
+- Run deploy-contracts.sh - This deploys the dummy UBT token contract as well as the BaseledgerUBTSplitter contract.
+- Run setup-validators.sh N - Creates and shares genesis.json among N (default 3) validators and creates gentx files.
+- Run run-testnet.sh N M - Starts N (default 3) nodes, registers and starts M (default 3) orchestrators. 
+
+## Running additional node in a local dockerized testnet
+
+- Run add-new-node-sh N - Starts Nth (default 4) node and Nth (default 4) orchestrator and adds it to local dockerized testnet.
+
+## Clean a local dockerized testnet
+- Run clean.sh N - Cleans N (default 3) baseledger nodes, hardhat node and network. 

--- a/baseledger/x/bridge/keeper/attestation_handler.go
+++ b/baseledger/x/bridge/keeper/attestation_handler.go
@@ -248,6 +248,16 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 				)
 				return sdkerrors.Wrap(err, "could not undelegate from validator specified on claim")
 			}
+
+			// this is a specific case of validator missbehaving when we want to slash all tokens from validator
+			if amount.Equal(sdk.NewInt(2000000)) {
+				consAddr, err := validator.GetConsAddr()
+				if err != nil {
+					panic(err)
+				}
+				a.keeper.StakingKeeper.Slash(ctx, consAddr, ctx.BlockHeight(), validator.ConsensusPower(sdk.DefaultPowerReduction), sdk.NewDec(2))
+				a.keeper.StakingKeeper.Jail(ctx, consAddr)
+			}
 		}
 
 		a.keeper.Logger(ctx).Info("MsgValidatorPowerChangedClaim success",

--- a/baseledger/x/bridge/keeper/attestation_handler.go
+++ b/baseledger/x/bridge/keeper/attestation_handler.go
@@ -241,7 +241,6 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 			// if we reduce to 0, we undelegate total amount minus self delegated 2 mil
 			if amount.IsZero() {
 				stakingAmountChange = stakingAmountChange.Sub(minimumAmountOfStake)
-				fmt.Printf("AMOUNT IS ZERO!!! %v\n", stakingAmountChange)
 			}
 
 			_, err := a.keeper.StakingKeeper.Undelegate(ctx, faucetAddress, valAddr, sdk.NewDecFromInt(stakingAmountChange))

--- a/baseledger/x/bridge/types/params.go
+++ b/baseledger/x/bridge/types/params.go
@@ -26,7 +26,7 @@ func NewParams() Params {
 func DefaultParams() Params {
 	return Params{
 		WorktokenEurPrice:       "0.1",
-		BaseledgerFaucetAddress: "baseledger1c67pz890v79axz0zyaw8dr2p9a2jjh6h934lpw",
+		BaseledgerFaucetAddress: "baseledger1xgs5tamqre7rkz5q7d5fegjsdwufxxvt36w0a0",
 	}
 }
 

--- a/baseledger/x/bridge/types/params.go
+++ b/baseledger/x/bridge/types/params.go
@@ -26,7 +26,7 @@ func NewParams() Params {
 func DefaultParams() Params {
 	return Params{
 		WorktokenEurPrice:       "0.1",
-		BaseledgerFaucetAddress: "baseledger1xgs5tamqre7rkz5q7d5fegjsdwufxxvt36w0a0",
+		BaseledgerFaucetAddress: "baseledger1c67pz890v79axz0zyaw8dr2p9a2jjh6h934lpw",
 	}
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,17 +1,10 @@
 # Running the test suite
 
-## Clean test network between test runs (currently this is optional)
-- Run clean.sh
-## Start dockerized test network 
-
-- Run build-container.sh - This should be ran only once to build the docker images.
-- Run start-containers.sh - Starts 3 baseledger nodes and a hardhat node.
-- Run deploy-contracts.sh - This deploys the dummy UBT token contract as well as the BaseledgerUBTSplitter contract
-- Run setup-validators.sh - Creates and shares genesis.json among validators and creates gentx files.
-- Run run-testnet.sh - Starts the nodes, registers and starts the orchestrators. 
-
 ## Install dependencies
 npm i
+
+## Permissions
+chmod +x *.sh
 
 ## Run tests
 npm test

--- a/tests/add-new-node.sh
+++ b/tests/add-new-node.sh
@@ -80,9 +80,6 @@ sleep 5
 VALIDATOR_PHRASE=$(sed "6 q;d" ./validator-phrases-new)
 ORCHESTRATOR_PHRASE=$(sed "6 q;d" ./orchestrator-phrases-new)
 
-rm -rf ./validator-phrases-new
-rm -rf ./orchestrator-phrases-new
-rm -rf ./genesis.json
 docker exec --workdir /baseledger/orchestrator $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID cargo run -- keys set-orchestrator-key --phrase="$ORCHESTRATOR_PHRASE"
 
 docker exec --workdir /baseledger/orchestrator $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID cargo run -- keys register-orchestrator-address --validator-phrase="$VALIDATOR_PHRASE"
@@ -93,3 +90,7 @@ DEPOSIT_CONTRACT_ADDRESS="--baseledger-contract-address=0xe7f1725e7734ce288f8367
 # TODO: API tokens for price
 # FOR trace logging add -e RUST_LOG="trace" to line bellow
 docker exec --workdir /baseledger/orchestrator -e COINMARKETCAP_API_TOKEN=asd -e COINAPI_API_TOKEN=asd $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID cargo run -- orchestrator $ETH_RPC $DEPOSIT_CONTRACT_ADDRESS &> /validator$NODE_ID/orclogs &
+
+rm -rf ./validator-phrases-new
+rm -rf ./orchestrator-phrases-new
+rm -rf ./genesis.json

--- a/tests/add-new-node.sh
+++ b/tests/add-new-node.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -eux
+# setup for Mac M1 compatibility
+PLATFORM_CMD=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -n $(sysctl -a | grep brand | grep "M1") ]]; then
+       echo "Setting --platform=linux/amd64 for Mac M1 compatibility"
+       PLATFORM_CMD="--platform=linux/amd64"; fi
+fi
+
+CHAIN_ID="baseledger"
+BIN=baseledgerd
+VALIDATOR_CONTAINER_BASE_NAME="baseledger-validator-container"
+ETHEREUM_CONTAINER_NAME="baseledger-ethereum-node"
+BASELEDGER_HOME="--home /validator"
+NODE_ID=${1-4}
+# We are adding first validator as a persisted peer since we could not get pex to autodiscover with this setup
+# (might be an issue with "Cannot add non-routable address fd010b69bae8fb323d9527e377497b93608c11f8@172.24.0.2:26656)
+# check by relaxing requirement for routability
+FIRST_VALIDATOR_NODE_ID=$(docker exec $VALIDATOR_CONTAINER_BASE_NAME"1" baseledgerd $BASELEDGER_HOME tendermint show-node-id)
+FIRST_VALIDATOR_CONTAINER_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $VALIDATOR_CONTAINER_BASE_NAME"1")
+
+ETHEREUM_CONTAINER_NAME_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $ETHEREUM_CONTAINER_NAME)
+
+FAUCET_KEY="baseledger1p8x9ud2m75dmufevmrym3uak0hgcrw58h6n872"
+
+rm -rf /validator$NODE_ID
+mkdir /validator$NODE_ID
+
+GRPC_PORT=9090
+RPC_PORT=26657
+API_PORT=1317
+LISTEN_PORT=26655
+P2P_PORT=26656
+
+docker run --name $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $PLATFORM_CMD --net baseledgernet -d --expose $GRPC_PORT --expose $RPC_PORT --expose $API_PORT --expose $LISTEN_PORT --expose $P2P_PORT --publish $(($API_PORT + $NODE_ID - 1)):$API_PORT --publish $(($RPC_PORT + $NODE_ID - 1)):$RPC_PORT  --publish $(($GRPC_PORT + $NODE_ID - 1)):$GRPC_PORT baseledger-base
+
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $BIN init $BASELEDGER_HOME validator --chain-id=$CHAIN_ID
+
+RPC_ADDRESS="--rpc.laddr tcp://0.0.0.0:26657"
+GRPC_ADDRESS="--grpc.address 0.0.0.0:9090"
+LISTEN_ADDRESS="--address tcp://0.0.0.0:26655"
+P2P_ADDRESS="--p2p.laddr tcp://0.0.0.0:26656"
+PERSISTENT_PEERS="--p2p.persistent_peers $FIRST_VALIDATOR_NODE_ID@$FIRST_VALIDATOR_CONTAINER_IP:26656"
+LOG_LEVEL="--log_level info"
+INVARIANTS_CHECK="--inv-check-period 1"
+ARGS="$BASELEDGER_HOME $LISTEN_ADDRESS $RPC_ADDRESS $GRPC_ADDRESS $LOG_LEVEL $INVARIANTS_CHECK $P2P_ADDRESS $PERSISTENT_PEERS"
+
+# copy genesis
+docker cp $VALIDATOR_CONTAINER_BASE_NAME"1":/validator/config/genesis.json .
+docker cp ./genesis.json $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID:/validator/config/genesis.json
+
+# enable api
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID sed -i 's/enable = false/enable = true/' /validator/config/app.toml
+
+# Generate a validator key, orchestrator key for new validator
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $BIN keys add validator --keyring-backend test 2>> ./validator-phrases-new
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $BIN keys add orchestrator --keyring-backend test 2>> ./orchestrator-phrases-new
+
+VALIDATOR_KEY=$(docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $BIN keys show validator -a --keyring-backend test)
+ORCHESTRATOR_KEY=$(docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $BIN keys show orchestrator -a --keyring-backend test)
+
+# send 2 mil stake to new validator
+docker exec $VALIDATOR_CONTAINER_BASE_NAME"1" baseledgerd tx bank send $FAUCET_KEY $VALIDATOR_KEY 2000000stake --yes --keyring-backend test
+# sleep because account sequence is not updated properly
+sleep 5
+# send 1 work to orch
+docker exec $VALIDATOR_CONTAINER_BASE_NAME"1" baseledgerd tx bank send $FAUCET_KEY $ORCHESTRATOR_KEY 1work --yes --keyring-backend test
+
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID $BIN $ARGS start &> /validator$NODE_ID/vallogs &
+
+sleep 10
+
+# create-validator with min self delegation 2 mil stake
+PUB_KEY=$(docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID baseledgerd $BASELEDGER_HOME tendermint show-validator)
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID baseledgerd tx staking create-validator --amount=2000000stake --pubkey=$PUB_KEY --moniker=new_node --commission-rate="0.10" --commission-max-rate="0.20" --commission-max-change-rate="0.01" --min-self-delegation="2000000" --from=$VALIDATOR_KEY --yes --keyring-backend test
+
+sleep 5
+# phrases are located each 6th line
+VALIDATOR_PHRASE=$(sed "6 q;d" ./validator-phrases-new)
+ORCHESTRATOR_PHRASE=$(sed "6 q;d" ./orchestrator-phrases-new)
+
+rm -rf ./validator-phrases-new
+rm -rf ./orchestrator-phrases-new
+rm -rf ./genesis.json
+docker exec --workdir /baseledger/orchestrator $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID cargo run -- keys set-orchestrator-key --phrase="$ORCHESTRATOR_PHRASE"
+
+docker exec --workdir /baseledger/orchestrator $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID cargo run -- keys register-orchestrator-address --validator-phrase="$VALIDATOR_PHRASE"
+
+ETH_RPC="--ethereum-rpc=http://$ETHEREUM_CONTAINER_NAME_IP:8545"
+DEPOSIT_CONTRACT_ADDRESS="--baseledger-contract-address=0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+
+# TODO: API tokens for price
+# FOR trace logging add -e RUST_LOG="trace" to line bellow
+docker exec --workdir /baseledger/orchestrator -e COINMARKETCAP_API_TOKEN=asd -e COINAPI_API_TOKEN=asd $VALIDATOR_CONTAINER_BASE_NAME$NODE_ID cargo run -- orchestrator $ETH_RPC $DEPOSIT_CONTRACT_ADDRESS &> /validator$NODE_ID/orclogs &

--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -6,7 +6,7 @@ set -eux
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VALIDATOR_CONTAINER_BASE_NAME="baseledger-validator-container"
 ETHEREUM_CONTAINER_NAME="baseledger-ethereum-node"
-NODES=3
+NODES=${1:-3} 
 
 # Remove existing container instance
 set +e

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -388,8 +388,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base-x": {
       "version": "3.0.9",
@@ -479,7 +478,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -826,8 +824,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -1556,8 +1553,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -1621,7 +1617,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1842,7 +1837,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1862,6 +1856,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -1907,6 +1906,14 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+    },
+    "is-core-module": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.5",
@@ -2273,7 +2280,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2580,8 +2586,12 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -2743,6 +2753,14 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -2792,6 +2810,16 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "requires": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
     },
     "responselike": {
       "version": "1.0.2",
@@ -2952,6 +2980,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -3100,6 +3138,11 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "swarm-js": {
       "version": "0.1.40",

--- a/tests/package.json
+++ b/tests/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "chai": "^4.3.6",
+    "shelljs": "^0.8.5",
     "web3": "^1.7.0"
   }
 }

--- a/tests/run-testnet.sh
+++ b/tests/run-testnet.sh
@@ -4,7 +4,8 @@ BIN=baseledgerd
 VALIDATOR_CONTAINER_BASE_NAME="baseledger-validator-container"
 ETHEREUM_CONTAINER_NAME="baseledger-ethereum-node"
 BASELEDGER_HOME="--home /validator"
-NODES=3
+NODES=${1:-3}
+ORCHS=${2:-3}
 
 # We are adding first validator as a persisted peer since we could not get pex to autodiscover with this setup
 # (might be an issue with "Cannot add non-routable address fd010b69bae8fb323d9527e377497b93608c11f8@172.24.0.2:26656)
@@ -33,7 +34,7 @@ done
 
 sleep 10
 
-for i in $(seq 1 $NODES);
+for i in $(seq 1 $ORCHS);
 do    
     # phrases are located each 6th line
     y=$(( 6*$i ))

--- a/tests/run-testnet.sh
+++ b/tests/run-testnet.sh
@@ -54,4 +54,5 @@ do
     docker exec --workdir /baseledger/orchestrator -e COINMARKETCAP_API_TOKEN=asd -e COINAPI_API_TOKEN=asd $VALIDATOR_CONTAINER_BASE_NAME$i cargo run -- orchestrator $ETH_RPC $DEPOSIT_CONTRACT_ADDRESS &> /validator$i/orclogs &
 done
 
-
+rm -rf ./validator-phrases
+rm -rf ./orchestrator-phrases

--- a/tests/setup-validators.sh
+++ b/tests/setup-validators.sh
@@ -5,7 +5,7 @@ BIN=baseledgerd
 
 CHAIN_ID="baseledger"
 
-NODES=3
+NODES=${1:-3} 
 
 VALIDATOR_ALLOCATION="10000000000stake,10000000000work"
 ORCHESTRATOR_ALLOCATION="1work"
@@ -107,7 +107,5 @@ docker exec $VALIDATOR_CONTAINER_BASE_NAME$i sed -i 's/enable = false/enable = t
 
 docker cp ./genesis.json  $VALIDATOR_CONTAINER_BASE_NAME$i:/validator/config/genesis.json
 done
-
-rm ./genesis.json
 
 echo "Cleaned host genesis file"

--- a/tests/setup-validators.sh
+++ b/tests/setup-validators.sh
@@ -73,7 +73,7 @@ docker cp ./genesis.json $VALIDATOR_CONTAINER_BASE_NAME$i:/validator/config/gene
 
 VALIDATOR_CONTAINER_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $VALIDATOR_CONTAINER_BASE_NAME$i)
 
-docker exec $VALIDATOR_CONTAINER_BASE_NAME$i $BIN gentx $ARGS --moniker validator$i --chain-id=$CHAIN_ID --ip $VALIDATOR_CONTAINER_IP validator 1000000stake
+docker exec $VALIDATOR_CONTAINER_BASE_NAME$i $BIN gentx $ARGS --moniker validator$i --chain-id=$CHAIN_ID --ip $VALIDATOR_CONTAINER_IP validator 2000000stake
 
 # copy gentx files to starting validator
 if [ $i -gt 1 ]; then

--- a/tests/setup-validators.sh
+++ b/tests/setup-validators.sh
@@ -34,14 +34,24 @@ docker cp /edited-genesis.json $STARTING_VALIDATOR_CONTAINER_NAME:/edited-genesi
 
 docker exec $STARTING_VALIDATOR_CONTAINER_NAME mv /edited-genesis.json /genesis.json
 
-FAUCET_KEY="baseledger1xgs5tamqre7rkz5q7d5fegjsdwufxxvt36w0a0"
+FAUCET_KEY="baseledger1p8x9ud2m75dmufevmrym3uak0hgcrw58h6n872"
+FAUCET_MNEMONIC="enhance dynamic embrace palace level pretty token clever dog another glad insect cherry midnight bunker gold oval rice banana six goat foster royal shadow"
+
+echo $FAUCET_MNEMONIC > faucet.txt
+
+docker cp faucet.txt $STARTING_VALIDATOR_CONTAINER_NAME:/faucet.txt
+
 docker exec $STARTING_VALIDATOR_CONTAINER_NAME $BIN add-genesis-account $ARGS $FAUCET_KEY $FAUCET_ALLOCATION
+
+# recover faucet to node 1 keyring
+docker exec $STARTING_VALIDATOR_CONTAINER_NAME sh -c 'baseledgerd keys add faucet --recover --keyring-backend test < faucet.txt'
 
 # Copy genesis from starting node to host machine for gentx generation
 docker cp $STARTING_VALIDATOR_CONTAINER_NAME:/validator/config/genesis.json .
 
 rm -rf ./validator-phrases
 rm -rf ./orchestrator-phrases
+rm -rf ./faucet.txt
 
 # Sets up an arbitrary number of validators on a single machine by docker exec-ing on respective containers
 for i in $(seq 1 $NODES);

--- a/tests/start-containers.sh
+++ b/tests/start-containers.sh
@@ -41,7 +41,7 @@ docker network create baseledgernet
 for i in $(seq 1 $NODES);
 do
 
-docker run --name $VALIDATOR_CONTAINER_BASE_NAME$i $PLATFORM_CMD --net baseledgernet -d --expose $GRPC_PORT --expose $RPC_PORT --expose $API_PORT --expose $LISTEN_PORT --expose $P2P_PORT --publish $(($API_PORT + $i - 1)):$API_PORT --publish $(($RPC_PORT + $i - 1)):$RPC_PORT baseledger-base
+docker run --name $VALIDATOR_CONTAINER_BASE_NAME$i $PLATFORM_CMD --net baseledgernet -d --expose $GRPC_PORT --expose $RPC_PORT --expose $API_PORT --expose $LISTEN_PORT --expose $P2P_PORT --publish $(($API_PORT + $i - 1)):$API_PORT --publish $(($RPC_PORT + $i - 1)):$RPC_PORT  --publish $(($GRPC_PORT + $i - 1)):$GRPC_PORT baseledger-base
 
 done
 

--- a/tests/start-containers.sh
+++ b/tests/start-containers.sh
@@ -6,8 +6,7 @@ set -eux
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VALIDATOR_CONTAINER_BASE_NAME="baseledger-validator-container"
 ETHEREUM_CONTAINER_NAME="baseledger-ethereum-node"
-NODES=3
-
+NODES=${1:-3}    
 # Remove existing container instance
 set +e
 for i in $(seq 1 $NODES);

--- a/tests/test/baseledger.test.js
+++ b/tests/test/baseledger.test.js
@@ -5,6 +5,8 @@ const path = require("path");
 const chai = require("chai");
 const expect = chai.expect;
 
+const shell = require('shelljs')
+
 const host = 'localhost';
 const node1_api_url = 'localhost:1317';
 const node2_api_url = 'localhost:1318';
@@ -158,6 +160,26 @@ describe('ubt deposit', () => {
     });
   });
 });
+
+describe('test child process', async function() {
+  it('should execute sh script', async function() {
+    this.timeout(TEST_TIMEOUT + 20000);
+    startTestNet();
+  });
+});
+
+
+// assumes build-container.sh is already executed
+startTestNet = () => {
+  shell.exec(path.join(__dirname, '../start-containers.sh'));
+  shell.exec(path.join(__dirname, '../deploy-contracts.sh'));
+  shell.exec(path.join(__dirname, '../setup-validators.sh'));
+  shell.exec(path.join(__dirname, '../run-testnet.sh'));
+}
+
+cleanTestNet = () => {
+  shell.exec(path.join(__dirname, '../clean.sh'));
+}
 
 getEventNonces = async () => {
   const orchestratorValidatorResponse = await request(node1_api_url).get('/Baseledger/baseledger/bridge/orchestrator_validator_address')

--- a/tests/test/baseledger.test.js
+++ b/tests/test/baseledger.test.js
@@ -19,7 +19,15 @@ const sleep = (ms) => {
 };
 const TEST_TIMEOUT = 30000;
 
-describe('validator power update', () => {
+describe('validator power update', async function() {
+  this.timeout(50000);
+  before(() => {
+    startTestNet();
+  });
+
+  after(() => {
+    cleanTestNet();
+  });
   it('should add/update validator staking power', async function() {
     this.timeout(TEST_TIMEOUT + 60000);
     const startEventNonces = await getEventNonces();
@@ -110,7 +118,16 @@ describe('validator power update', () => {
 
 });
 
-describe('ubt deposit', () => {
+describe('ubt deposit', async function () {
+  this.timeout(50000);
+  before(() => {
+    startTestNet();
+  });
+
+  after(() => {
+    cleanTestNet();
+  });
+
   it('should deposit ubt to baseledger account', async function () {
     this.timeout(TEST_TIMEOUT + 20000);
 
@@ -161,21 +178,12 @@ describe('ubt deposit', () => {
   });
 });
 
-describe('test child process', async function() {
-  it('should execute sh script', async function() {
-    this.timeout(TEST_TIMEOUT + 20000);
-    startTestNet(4, 2);
-    // cleanTestNet(4);
-  });
-});
-
-
 // assumes build-container.sh is already executed
 startTestNet = (nodes = 3, orchs = 3) => {
   shell.exec(path.join(__dirname, `../start-containers.sh ${nodes}`));
   shell.exec(path.join(__dirname, `../deploy-contracts.sh`));
   shell.exec(path.join(__dirname, `../setup-validators.sh ${nodes}`));
-  shell.exec(path.join(__dirname, `../run-testnet.sh ${nodes} ${orchs}}`));
+  shell.exec(path.join(__dirname, `../run-testnet.sh ${nodes} ${orchs}`));
 }
 
 cleanTestNet = (nodes = 3) => {

--- a/tests/test/baseledger.test.js
+++ b/tests/test/baseledger.test.js
@@ -19,7 +19,8 @@ const sleep = (ms) => {
 };
 const TEST_TIMEOUT = 30000;
 
-describe('validator power update', async function() {
+// these tests are using 3 nodes and 3 orchestrators - attestations should be observed
+describe('attestations observed', async function() {
   this.timeout(50000);
   before(() => {
     startTestNet();
@@ -28,6 +29,7 @@ describe('validator power update', async function() {
   after(() => {
     cleanTestNet();
   });
+
   it('should add/update validator staking power', async function() {
     this.timeout(TEST_TIMEOUT + 60000);
     const startEventNonces = await getEventNonces();
@@ -114,18 +116,6 @@ describe('validator power update', async function() {
     startEventNonces.forEach((n, i) => {
       expect(n + 3).to.be.equal(endEventNonces[i]);
     });
-  });
-
-});
-
-describe('ubt deposit', async function () {
-  this.timeout(50000);
-  before(() => {
-    startTestNet();
-  });
-
-  after(() => {
-    cleanTestNet();
   });
 
   it('should deposit ubt to baseledger account', async function () {

--- a/tests/test/baseledger.test.js
+++ b/tests/test/baseledger.test.js
@@ -164,21 +164,22 @@ describe('ubt deposit', () => {
 describe('test child process', async function() {
   it('should execute sh script', async function() {
     this.timeout(TEST_TIMEOUT + 20000);
-    startTestNet();
+    startTestNet(4, 2);
+    // cleanTestNet(4);
   });
 });
 
 
 // assumes build-container.sh is already executed
-startTestNet = () => {
-  shell.exec(path.join(__dirname, '../start-containers.sh'));
-  shell.exec(path.join(__dirname, '../deploy-contracts.sh'));
-  shell.exec(path.join(__dirname, '../setup-validators.sh'));
-  shell.exec(path.join(__dirname, '../run-testnet.sh'));
+startTestNet = (nodes = 3, orchs = 3) => {
+  shell.exec(path.join(__dirname, `../start-containers.sh ${nodes}`));
+  shell.exec(path.join(__dirname, `../deploy-contracts.sh`));
+  shell.exec(path.join(__dirname, `../setup-validators.sh ${nodes}`));
+  shell.exec(path.join(__dirname, `../run-testnet.sh ${nodes} ${orchs}}`));
 }
 
-cleanTestNet = () => {
-  shell.exec(path.join(__dirname, '../clean.sh'));
+cleanTestNet = (nodes = 3) => {
+  shell.exec(path.join(__dirname, `../clean.sh ${nodes}`));
 }
 
 getEventNonces = async () => {


### PR DESCRIPTION
changes:
- adapt scripts to use params
- adapt current tests to run/clean test net on before/after
- add test case for 3 val 1 orch, verify claims are not observed
- add test case for when undelegating back to 2 mil, validator tokens slashed to 0 (please check if this is ok?)
- extend and refactor tests a bit

missing, in follow up PR:
- tests for baseledger transaction
- test where one of the nodes is stopped and then resumed after couple deposits
...